### PR TITLE
use active python kernel for mpiexec

### DIFF
--- a/qaoa-for-max-cut/03_Recursive-divide-and-conquer.ipynb
+++ b/qaoa-for-max-cut/03_Recursive-divide-and-conquer.ipynb
@@ -1924,7 +1924,11 @@
       ],
       "source": [
         "# MPI call\n",
-        "!mpiexec -np 4 --allow-run-as-root python3 Example-03.py"
+        "import sys\n",
+        "print(sys.executable)\n",
+        "python_path = sys.executable\n",
+        "\n",
+        "!mpiexec -np 4 {python_path} Example-03.py"
       ]
     },
     {


### PR DESCRIPTION
This changes the mpiexec call to use the active python kernel rather than the base python environment.