### PR TITLE
Updates to DockerFile and Instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,16 @@
-FROM nvcr.io/nvidia/quantum/cuda-quantum:0.7.1
+FROM nvcr.io/nvidia/quantum/cuda-quantum:cu12-0.11.0
 WORKDIR /app
-ADD requirements.txt /app
-RUN pip install -r /app/requirements.txt
-ADD *.ipynb *.py images/ /app/
+RUN pip install --upgrade pip setuptools wheel
+RUN pip install cudaq
+COPY dynamics101/ /app/dynamics101/ 
+COPY images/ /app/images/ 
+COPY qaoa-for-max-cut/ /app/qaoa-for-max-cut/ 
+COPY qec101/ /app/qec101/ 
+COPY qis-examples/ /app/qis-examples/ 
+COPY quick-start-to-quantum/ /app/quick-start-to-quantum/ 
+COPY quantum-applications-to-finance/ /app/quantum-applicaitons-to-finance/
+ADD *.ipynb *.py /app/
 ENV JUPYTER_LAB_PORT=8888
 EXPOSE ${JUPYTER_LAB_PORT}
 ENTRYPOINT []
-CMD /usr/local/bin/jupyter-lab --port=${JUPYTER_LAB_PORT} --NotebookApp.token=''
+CMD /usr/local/bin/jupyter-lab --port=${JUPYTER_LAB_PORT} --ip=0.0.0.0 --NotebookApp.token='' 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM nvcr.io/nvidia/quantum/cuda-quantum:cu12-0.11.0
 WORKDIR /app
 RUN pip install --upgrade pip setuptools wheel
-RUN pip install cudaq
+RUN pip install cudaq==0.12.0
 COPY dynamics101/ /app/dynamics101/ 
 COPY images/ /app/images/ 
 COPY qaoa-for-max-cut/ /app/qaoa-for-max-cut/ 

--- a/instructions.md
+++ b/instructions.md
@@ -17,33 +17,36 @@ customize this container, make edits to the included `Dockerfile`.
 docker login nvcr.io
 # Follow the login instructions at ngc.nvidia.com
 # Next, build the container locally
-docker build -t cuda-quantum-academic:latest
+docker build -t cuda-quantum-academic:latest .
 ```
 
-To run the container, use the following command. By default Jupyter-lab will
-use port 8888 and docker will expose this port. If you wish to use a different
-port, see the directions below.
+To run the container, use the following command. 
 
 ```sh
-docker run cuda-quantum-academic:latest
+docker run -p 8888:8888 -e JUPYTER_ENABLE_LAB=yes cuda-quantum-academic:latest
 ```
 
 You can now open a web browser to http://localhost:8888/lab to access the labs.
 
 ### Changing the port
-You can either change the port that will be used by jupyter-lab at build time
-(more permanent) or at runtime (more dynamic).
+If you cannot use port 8888 on your local machine then you can specify a differnt
+port when running the the container.  For example, if you want to connect to your 
+Jupyter Lab on port 8000 using http://localhost:8000/lab, then you'd do the following:
 
-Build time:
-```sh
-docker build --build-arg JUPYTER_LAB_PORT=8000 -t cuda-quantum-academic:latest
-docker run cuda-quantum-academic:latest
-```
-
-Run time:
 ```sh
 docker run -p 8000:8888 cuda-quantum-academic:latest
 ```
+
+Here `8888` is the port used within the container. Docker is routing your local 
+traffic on `8000` to the container port `8888`.  If you need to change the port used within
+the container, then you can also specify that port when running your container. For example,
+if you wish to direct your browser to port 8888 but run the Jupyter lab within the container 
+on port 8000, then you'd run the following: 
+
+```sh
+docker run -e JUPYTER_LAB_PORT=8000 -p 8888:8000  -e JUPYTER_ENABLE_LAB=yes cuda-quantum-academic:latest
+```
+
 
 ## Running the notebooks in Google Colab
 Simply click on the icon at the top of each notebook in github to open it up in Google Colab.  In each notebook there instructions for running CoLab.

--- a/instructions.md
+++ b/instructions.md
@@ -23,7 +23,7 @@ docker build -t cuda-quantum-academic:latest .
 To run the container, use the following command. 
 
 ```sh
-docker run -p 8888:8888 -e JUPYTER_ENABLE_LAB=yes cuda-quantum-academic:latest
+docker run -p 8888:8888 cuda-quantum-academic:latest
 ```
 
 You can now open a web browser to http://localhost:8888/lab to access the labs.
@@ -44,7 +44,7 @@ if you wish to direct your browser to port 8888 but run the Jupyter lab within t
 on port 8000, then you'd run the following: 
 
 ```sh
-docker run -e JUPYTER_LAB_PORT=8000 -p 8888:8000  -e JUPYTER_ENABLE_LAB=yes cuda-quantum-academic:latest
+docker run -e JUPYTER_LAB_PORT=8000 -p 8888:8000  cuda-quantum-academic:latest
 ```
 
 


### PR DESCRIPTION
The existing DockerFile and the instructions for using it did not appear to work, or they did not work on my system at least. The image build failed installing python requirements and the labs themselves were not copied into the container.  The DockerFile in this PR addresses those issues and builds against the latest Cuda-Q container and PyPi library.  I've updated instructions.md to go along with the new build.  

The new container build should let people interact with and run all the labs locally as well on the cloud through Colab, CoCalc, or qBraid. If they want to make persistent edits or develop labs through the docker container, then they'll need to use a volume (or something like that) a la [https://docs.docker.com/guides/jupyter/](https://docs.docker.com/guides/jupyter/).       


