### PR TITLE
Update torch version in diffusion model notebooks

### DIFF
--- a/ai-for-quantum/01_compiling_unitaries_using_diffusion_models.ipynb
+++ b/ai-for-quantum/01_compiling_unitaries_using_diffusion_models.ipynb
@@ -42,7 +42,7 @@
     "# Uncomment and execute the following lines if you are working in an environment without these packages already installed\n",
     "#!pip install cudaq\n",
     "#!pip install genQC==0.1.0\n",
-    "#!pip install torch==2.7.0\n",
+    "#!pip install torch==2.8.0\n",
     "#!pip install numpy==2.2.6"
    ]
   },


### PR DESCRIPTION
Updating torch from 2.7.0 to 2.8.0 which fixed dependency error in Colab