### PR TITLE
Adapt parallel fixes

### DIFF
--- a/chemistry-simulations/adapt_vqe.ipynb
+++ b/chemistry-simulations/adapt_vqe.ipynb
@@ -954,7 +954,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "ADAPT methods can also be generalized beyond chemistry and extend to problems like QAOA.  [This tutorial](https://nvidia.github.io/cuda-quantum/latest/applications/python/adapt_qaoa.html) in the CUDA-Q docs demonstrates how one can setup a QAOA problem and iteratively add layers where the mixer Hamiltonian is selected via the ADAPT process, leading to faster convergence. If you have completed the series [Divide-and-Conquer QAOA for MaxCut](https://github.com/NVIDIA/cuda-q-academic/tree/main/qaoa-for-max-cut), a good exercise might be to revisit your code and try improving it with it with ADAPT-QAOA. \n",
+    "ADAPT methods can also be generalized beyond chemistry and extend to problems like QAOA.  [This tutorial](https://nvidia.github.io/cuda-quantum/latest/applications/python/adapt_qaoa.html) in the CUDA-Q docs demonstrates how one can setup a QAOA problem and iteratively add layers where the mixer Hamiltonian is selected via the ADAPT process, leading to faster convergence. If you have completed the series [Divide-and-Conquer QAOA for MaxCut](https://github.com/NVIDIA/cuda-q-academic/tree/main/qaoa-for-max-cut), a good exercise might be to revisit your code and try improving it with ADAPT-QAOA. \n",
     "\n",
     "Though ADAPT methods have clear benefits over conventional variational algorithms, they still suffer from the same fundamental measurements problems and barren plateaus for large problem sizes. Nevertheless, they are fantastic drop-in substitutions for any situation where a variation method is used for a subroutine like state preparation. \n",
     "\n",

--- a/chemistry-simulations/solutions/adapt_vqe_solutions.ipynb
+++ b/chemistry-simulations/solutions/adapt_vqe_solutions.ipynb
@@ -542,8 +542,6 @@
     "    \n",
     "    else:\n",
     "\n",
-    "\n",
-    "\n",
     "        \n",
     "        #TODO-2:  Find the operator corresponding to the largest gradient element.\n",
     "        #Add this operator and its coefficient to the appropriate single or doubles list.\n",
@@ -1015,7 +1013,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "ADAPT methods can also be generalized beyond chemistry and extend to problems like QAOA.  [This tutorial](https://nvidia.github.io/cuda-quantum/latest/applications/python/adapt_qaoa.html) in the CUDA-Q docs demonstrates how one can setup a QAOA problem and iteratively add layers where the mixer Hamiltonian is selected via the ADAPT process, leading to faster convergence. If you have completed the series [Divide-and-Conquer QAOA for MaxCut](https://github.com/NVIDIA/cuda-q-academic/tree/main/qaoa-for-max-cut), a good exercise might be to revisit your code and try improving it with it with ADAPT-QAOA. \n",
+    "ADAPT methods can also be generalized beyond chemistry and extend to problems like QAOA.  [This tutorial](https://nvidia.github.io/cuda-quantum/latest/applications/python/adapt_qaoa.html) in the CUDA-Q docs demonstrates how one can setup a QAOA problem and iteratively add layers where the mixer Hamiltonian is selected via the ADAPT process, leading to faster convergence. If you have completed the series [Divide-and-Conquer QAOA for MaxCut](https://github.com/NVIDIA/cuda-q-academic/tree/main/qaoa-for-max-cut), a good exercise might be to revisit your code and try improving it with ADAPT-QAOA. \n",
     "\n",
     "Though ADAPT methods have clear benefits over conventional variational algorithms, they still suffer from the same fundamental measurements problems and barren plateaus for large problem sizes. Nevertheless, they are fantastic drop-in substitutions for any situation where a variation method is used for a subroutine like state preparation. \n",
     "\n",


### PR DESCRIPTION
Fixed how ADAPT-VQE parallel section worked.  

- removed double loop over "i"
- Removed `get_state_async` from loop
- For gradient, added `.get()` after both shifts are computed.